### PR TITLE
Added optional size parameter to custom faces endpoint

### DIFF
--- a/lib/imager.coffee
+++ b/lib/imager.coffee
@@ -5,11 +5,10 @@ class Imager
   minSize: 40
   maxSize: 400
 
-  combine: (face, size, callback) ->
-    if callback?
+  combine: (face, callback, size) ->
+    if size
       size = @_parseSize(size)
     else
-      callback = size
       size = width: @maxSize, height: @maxSize
 
     imageMagick()

--- a/lib/imager.coffee
+++ b/lib/imager.coffee
@@ -5,7 +5,7 @@ class Imager
   minSize: 40
   maxSize: 400
 
-  combine: (face, callback, size) ->
+  combine: (face, size, callback) ->
     if size
       size = @_parseSize(size)
     else

--- a/lib/routes/v2.coffee
+++ b/lib/routes/v2.coffee
@@ -22,12 +22,12 @@ router.get '/list', (req, res, next) ->
     .send(response)
 
 router.get '/:id', (req, res, next) ->
-  imager.combine req.faceParts, (err, stdout) ->
+  imager.combine req.faceParts, false, (err, stdout) ->
     common.sendImage(err, stdout, req, res, next)
 
 # with custom size
 router.get '/:size/:id', (req, res, next) ->
-  imager.combine req.faceParts, (err, stdout) ->
+  imager.combine req.faceParts, req.params.size, (err, stdout) ->
     common.sendImage(err, stdout, req, res, next)
   , req.params.size
 

--- a/lib/routes/v2.coffee
+++ b/lib/routes/v2.coffee
@@ -27,11 +27,12 @@ router.get '/:id', (req, res, next) ->
 
 # with custom size
 router.get '/:size/:id', (req, res, next) ->
-  imager.combine req.faceParts, req.params.size, (err, stdout) ->
+  imager.combine req.faceParts, (err, stdout) ->
     common.sendImage(err, stdout, req, res, next)
+  , req.params.size
 
 # with custom face parts
-router.get '/face/:eyes/:nose/:mouth/:color', (req, res, next) ->
+router.get '/face/:eyes/:nose/:mouth/:color/:size?', (req, res, next) ->
   faceParts = color: "##{req.params.color}"
 
   partTypes.forEach (type) ->
@@ -49,5 +50,6 @@ router.get '/face/:eyes/:nose/:mouth/:color', (req, res, next) ->
 
   imager.combine faceParts, (err, stdout) ->
     common.sendImage(err, stdout, req, res, next)
+  , req.params.size
 
 module.exports = router

--- a/lib/routes/v2.coffee
+++ b/lib/routes/v2.coffee
@@ -48,8 +48,7 @@ router.get '/face/:eyes/:nose/:mouth/:color/:size?', (req, res, next) ->
 
     faceParts[type] = ImageFiles.pathFor(type, fileName)
 
-  imager.combine faceParts, (err, stdout) ->
+  imager.combine faceParts, req.params.size, (err, stdout) ->
     common.sendImage(err, stdout, req, res, next)
-  , req.params.size
 
 module.exports = router


### PR DESCRIPTION
Solves issue #41.

Optional size parameter added which keeps backwards compatibility. I did swap the size and callback parameters when calling combine in order to keep consistency within the endpoints.
