### PR TITLE
Gulpfile cleanup

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -154,7 +154,7 @@ gulp.task('assets', function() {
 //
 
 gulp.task('clean', function() {
-  return del(paths.cleanPath, { sync: true });
+  return del.sync(paths.cleanPath);
 });
 
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -18,6 +18,7 @@ var del, livereload, runSequence;
 
 if (process.env.NODE_ENV == "development") {
   del         = require('del'),
+  colors      = require('colors'),
   livereload  = require('gulp-livereload'),
   runSequence = require('run-sequence'),
   findPort    = require('find-port');


### PR DESCRIPTION
I was getting a couple of errors from the `clean` task that I think were caused by using the deprecated `{ sync: true }` option instead of the `del.sync` API.

There was also a log attempting to use `colors` when the LiveReload server started, but `colors` wasn't required.
