### PR TITLE
Track Remote IPs

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -15,6 +15,8 @@ const app = express();
 const basePath = path.join(__dirname, '..');
 const faviconPath = path.join(basePath, 'src', 'favicon.ico');
 
+app.set('trust proxy', true);
+
 app.use(favicon(faviconPath));
 app.get('/', function(req, res) {
   return res.redirect('http://avatars.adorable.io');


### PR DESCRIPTION
We're currently getting a bunch of garbage (10.x IPs) from `req.ip`,
potentially due to the fact that we're only using the IP and not the
X-Forwarded-For header from the request. With this setting, we should be able
to get the "true" IP of the request (if it's there).

See http://expressjs.com/en/api.html#req.ip for more info on the
property and this related setting.